### PR TITLE
Accounting for floating point error.

### DIFF
--- a/4_cross_correlation.ipynb
+++ b/4_cross_correlation.ipynb
@@ -317,7 +317,7 @@
    "source": [
     "x = torch.randn(4, 4)\n",
     "w = torch.randn(2, 2)\n",
-    "torch.equal(torch.nn.functional.conv2d(x[None, :], w[None, None, :])[0], conv2d(x, w))"
+    "torch.allclose(torch.nn.functional.conv2d(x[None, :], w[None, None, :])[0], conv2d(x, w))"
    ]
   },
   {


### PR DESCRIPTION
Changed to torch.allclose instead of torch.equal because on other machines (such as my own), using the provided answer gives a difference of 2.9802e-08 from the torch.nn.functional.conv2d function for row 3 column 2 ( entry at [2,1] ).