### PR TITLE
Update 4_cross_correlation.ipynb. Added dtype=float

### DIFF
--- a/4_cross_correlation.ipynb
+++ b/4_cross_correlation.ipynb
@@ -498,6 +498,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "dtype=float\n",
     "conv2d = nn.Conv2d(in_channels=1, out_channels=1, kernel_size=(3, 3), dtype=dtype, device=device)"
    ]
   },

--- a/4_cross_correlation.ipynb
+++ b/4_cross_correlation.ipynb
@@ -498,7 +498,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dtype=float\n",
+    "dtype=torch.get_default_dtype()\n",
     "conv2d = nn.Conv2d(in_channels=1, out_channels=1, kernel_size=(3, 3), dtype=dtype, device=device)"
    ]
   },


### PR DESCRIPTION
On my own system, dtype wasn't predefined, which caused a number of problems in the python environment, so I explicitly defined dtype to be equal to float.